### PR TITLE
Fix crash if packaged block was placed by no entity

### DIFF
--- a/src/main/java/gigaherz/packingtape/tape/PackagedBlock.java
+++ b/src/main/java/gigaherz/packingtape/tape/PackagedBlock.java
@@ -104,7 +104,7 @@ public class PackagedBlock extends Block implements EntityBlock
     @Override
     public void setPlacedBy(Level worldIn, BlockPos pos, BlockState state, LivingEntity placer, ItemStack stack)
     {
-        if (!placer.isShiftKeyDown() && placer instanceof Player)
+        if (placer instanceof Player && !placer.isShiftKeyDown())
         {
             Player player = (Player) placer;
             PackagedBlockEntity te = (PackagedBlockEntity) worldIn.getBlockEntity(pos);


### PR DESCRIPTION
If the packaged block was placed by a block placer block, LivingEntity would be null (This is allowed because the parameter is annotated with Nullable in the base class) and the game instance or server would crash.