### PR TITLE
Make packing IC2 machines impossible

### DIFF
--- a/src/main/java/gigaherz/packingtape/Config.java
+++ b/src/main/java/gigaherz/packingtape/Config.java
@@ -88,6 +88,11 @@ public class Config
         if (net.minecraft.tileentity.TileEntityBed.class.isAssignableFrom(teClass))
             return false;
 
+        //blacklist IC2 machines; they turn into invalid tiles upon unpacking
+        if (te.getWorld().getBlockState(te.getPos()).getBlock().getRegistryName().toString().equals("ic2:te"))
+            return false;
+
+
         // TODO: Blacklist more Vanilla stuffs.
 
         return true;


### PR DESCRIPTION
Machines from IndustrialCraft 2 do not interact nicely with packing tape; when unpacked, they result in "invalid" tile entities under IC2's strange architecture, causing item loss.

Since IC2 is closed source, I don't think it is possible to solve the issue on their end or to expose the underlying problem causing packing tape to fail on IC2 entities; therefore, since the result of using packing tape on IC2 machines is so bad, I think blocking them unilaterally is worthwhile.